### PR TITLE
Feat: Support multiple modals for use inside for-loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,155 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Modal support for streamlit. The hackish way.
 
 ```python
 import streamlit as st
-import streamlit_modal as modal
+from streamlit_modal import Modal
 
 import streamlit.components.v1 as components
 
 
+modal = Modal("Demo Modal")
 open_modal = st.button("Open")
 if open_modal:
     modal.open()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def setup_package():
     setup(
         name="streamlit_modal",
         install_requires=['streamlit', 'deprecation'],
-        version="0.0.6",
+        version="0.1.0",
         author="Koen Vossen",
         author_email="info@koenvossen.nl",
         url="https://github.com/teamtv/streamlit_modal",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ def setup_package():
 
     setup(
         name="streamlit_modal",
-        version="0.0.5",
+        install_requires=['streamlit', 'deprecation'],
+        version="0.0.6",
         author="Koen Vossen",
         author_email="info@koenvossen.nl",
         url="https://github.com/teamtv/streamlit_modal",

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -1,115 +1,150 @@
+from uuid import uuid4
 from contextlib import contextmanager
 
 import streamlit as st
 import streamlit.components.v1 as components
 
 
+class Modal:
+
+    def __init__(self, title, padding=100, max_width=None, background_color='#fff', key=None):
+        self.title = title
+        self.padding = padding
+        self.backgroud_color = background_color
+        self.max_width = max_width
+        self.key = key or f'streamlit-modal-{uuid4().hex}'
+
+    def is_open(self):
+        return st.session_state.get(f'{self.key}-opened', False)
+
+    def open(self):
+        st.session_state[f'{self.key}-opened'] = True
+        st.experimental_rerun()
+
+    def close(self):
+        st.session_state[f'{self.key}-opened'] = False
+        st.experimental_rerun()
+
+    @contextmanager
+    def container(self):
+        if self.max_width:
+            max_width = str(self.max_width) + "px"
+        else:
+            max_width = 'unset'
+
+        st.markdown(
+            f"""
+            <style>
+            div[data-modal-container='true'][key='{self.key}'] {{
+                position: fixed;
+                width: 100vw !important;
+                left: 0;
+                z-index: 1001;
+            }}
+
+            div[data-modal-container='true'][key='{self.key}'] > div:first-child {{
+                margin: auto;
+            }}
+
+            div[data-modal-container='true'][key='{self.key}'] h1 a {{
+                display: none
+            }}
+
+            div[data-modal-container='true'][key='{self.key}']::before {{
+                    position: fixed;
+                    content: ' ';
+                    left: 0;
+                    right: 0;
+                    top: 0;
+                    bottom: 0;
+                    z-index: 1000;
+                    background-color: rgba(0, 0, 0, 0.5);
+            }}
+            div[data-modal-container='true'][key='{self.key}'] > div:first-child {{
+                max-width: {max_width};
+            }}
+
+            div[data-modal-container='true'][key='{self.key}'] > div:first-child > div:first-child {{
+                width: unset !important;
+                background-color: {self.backgroud_color};     
+                padding: {self.padding}px;
+                margin-top: -{self.padding}px;
+                margin-left: -{self.padding}px;
+                margin-bottom: -{2*self.padding}px;
+                z-index: 1001;
+                border-radius: 5px;
+            }}
+            div[data-modal-container='true'][key='{self.key}'] > div > div:nth-child(2)  {{
+                z-index: 1003;
+                position: absolute;
+            }}
+            div[data-modal-container='true'][key='{self.key}'] > div > div:nth-child(2) > div {{
+                text-align: right;
+                padding-right: {self.padding}px;
+                max-width: {max_width};
+            }}
+
+            div[data-modal-container='true'][key='{self.key}'] > div > div:nth-child(2) > div > button {{
+                right: 0;
+            }}
+            </style>
+            """,
+            unsafe_allow_html=True
+        )
+        with st.container():
+            _container = st.container()
+            if self.title:
+                _container.markdown(
+                    f"<h1>{self.title}</h1>", unsafe_allow_html=True)
+
+            close_ = st.button('X', key=f'{self.key}-close')
+            if close_:
+                self.close()
+
+        components.html(
+            f"""
+            <script>
+            // STREAMLIT-MODAL-IFRAME-{self.key} <- Don't remove this comment. It's used to find our iframe
+            const iframes = parent.document.body.getElementsByTagName('iframe');
+            let container
+            for(const iframe of iframes)
+            {{
+            if (iframe.srcdoc.indexOf("STREAMLIT-MODAL-IFRAME-{self.key}") !== -1) {{
+                container = iframe.parentNode.previousSibling;
+                container.setAttribute('data-modal-container', 'true');
+                container.setAttribute('key', '{self.key}');
+            }}
+            }}
+            </script>
+            """,
+            height=0, width=0
+        )
+
+        with _container:
+            yield _container
+
+
+# keep compatible with old api
+
+_default_modal = Modal('', key='streamlit-modal-default')
+
+
 def is_open():
-    return st.session_state.get('modal_is_open', False)
+    return _default_modal.is_open()
 
 
-def open():
-    st.session_state.modal_is_open = True
-    st.experimental_rerun()
+def open():  # pylin: disable=redefined-builtin
+    return _default_modal.open()
 
 
 def close():
-    st.session_state.modal_is_open = False
-    st.experimental_rerun()
+    return _default_modal.close()
 
 
 @contextmanager
 def container(title=None, padding=100, max_width=None):
-    if max_width:
-        max_width = str(max_width) + "px";
-    else:
-        max_width = 'unset';
-
-    st.markdown(
-        """
-        <style>
-        div[data-modal-container='true'] {
-            position: fixed;
-            width: 100vw !important;
-            left: 0;
-            z-index: 1001;
-        }
-
-        div[data-modal-container='true'] > div:first-child {
-            margin: auto;
-        }
-
-        div[data-modal-container='true'] h1 a {
-            display: none
-        }
-
-        div[data-modal-container='true']::before {
-                position: fixed;
-                content: ' ';
-                left: 0;
-                right: 0;
-                top: 0;
-                bottom: 0;
-                z-index: 1000;
-                background-color: rgba(0, 0, 0, 0.5);
-        }
-        div[data-modal-container='true'] > div:first-child {
-            max-width: """ + max_width + """;
-        }
-
-        div[data-modal-container='true'] > div:first-child > div:first-child {
-            width: unset !important;
-            background-color: #f0f0f0;     
-            padding: """ + str(padding) + """px;
-            margin-top: -""" + str(padding) + """px;
-            margin-left: -""" + str(padding) + """px;
-            margin-bottom: -""" + str(2 * padding) + """px;
-            z-index: 1001;
-            border-radius: 5px;
-        }
-        div[data-modal-container='true'] > div > div:nth-child(2)  {
-            z-index: 1003;
-            position: absolute;
-        }
-        div[data-modal-container='true'] > div > div:nth-child(2) > div {
-            text-align: right;
-            padding-right: """ + str(padding) + """px;
-            max-width: """ + max_width + """;
-        }
-
-        div[data-modal-container='true'] > div > div:nth-child(2) > div > button {
-            right: 0;
-        }
-        </style>
-        """,
-        unsafe_allow_html=True
-    )
-    with st.container():
-        _container = st.container()
-        if title:
-            _container.markdown(f"<h1>{title}</h1>", unsafe_allow_html=True)
-
-        close_ = st.button('X')
-        if close_:
-            close()
-
-    components.html(
-        """
-        <script>
-        // STREAMLIT-MODAL-IFRAME <- Don't remove this comment. It's used to find our iframe
-        const iframes = parent.document.body.getElementsByTagName('iframe');
-        let container
-        for(const iframe of iframes)
-        {
-          if (iframe.srcdoc.indexOf("STREAMLIT-MODAL-IFRAME") !== -1) {
-            container = iframe.parentNode.previousSibling;
-            container.setAttribute('data-modal-container', 'true');
-          }
-        }
-        </script>
-        """,
-        height=0, width=0
-    )
-
-    with _container:
-        yield _container
+    _default_modal.title = title
+    _default_modal.padding = padding
+    _default_modal.max_width = max_width
+    with _default_modal.container() as _container:
+        yield [_container]

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -20,9 +20,10 @@ class Modal:
         st.session_state[f'{self.key}-opened'] = True
         st.experimental_rerun()
 
-    def close(self):
+    def close(self, rerun=True):
         st.session_state[f'{self.key}-opened'] = False
-        st.experimental_rerun()
+        if rerun:
+            st.experimental_rerun()
 
     @contextmanager
     def container(self):

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -1,4 +1,3 @@
-from uuid import uuid4
 from contextlib import contextmanager
 
 from deprecation import deprecated
@@ -8,11 +7,11 @@ import streamlit.components.v1 as components
 
 class Modal:
 
-    def __init__(self, title, padding=100, max_width=None, key=None):
+    def __init__(self, title, key, padding=20, max_width=None):
         self.title = title
         self.padding = padding
         self.max_width = max_width
-        self.key = key or f'streamlit-modal-{uuid4().hex}'
+        self.key = key
 
     def is_open(self):
         return st.session_state.get(f'{self.key}-opened', False)
@@ -66,10 +65,11 @@ class Modal:
 
             div[data-modal-container='true'][key='{self.key}'] > div:first-child > div:first-child {{
                 width: unset !important;
-                background-color: #fff;     
+                background-color: #fff;
                 padding: {self.padding}px;
                 margin-top: -{self.padding}px;
                 margin-left: -{self.padding}px;
+                margin-right: -{self.padding}px;
                 margin-bottom: -{2*self.padding}px;
                 z-index: 1001;
                 border-radius: 5px;
@@ -95,7 +95,7 @@ class Modal:
             _container = st.container()
             if self.title:
                 _container.markdown(
-                    f"<h1>{self.title}</h1>", unsafe_allow_html=True)
+                    f"<h2>{self.title}</h2>", unsafe_allow_html=True)
 
             close_ = st.button('X', key=f'{self.key}-close')
             if close_:

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -8,10 +8,9 @@ import streamlit.components.v1 as components
 
 class Modal:
 
-    def __init__(self, title, padding=100, max_width=None, background_color='#fff', key=None):
+    def __init__(self, title, padding=100, max_width=None, key=None):
         self.title = title
         self.padding = padding
-        self.backgroud_color = background_color
         self.max_width = max_width
         self.key = key or f'streamlit-modal-{uuid4().hex}'
 
@@ -67,7 +66,7 @@ class Modal:
 
             div[data-modal-container='true'][key='{self.key}'] > div:first-child > div:first-child {{
                 width: unset !important;
-                background-color: {self.backgroud_color};     
+                background-color: #fff;     
                 padding: {self.padding}px;
                 margin-top: -{self.padding}px;
                 margin-left: -{self.padding}px;
@@ -129,28 +128,28 @@ class Modal:
 
 _default_modal = Modal('', key='streamlit-modal-default')
 
-@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
-                        current_version='0.0.6',
+@deprecated(deprecated_in="0.1.0", removed_in="1.0.0",
+                        current_version='0.1.0',
                         details="Use the `Modal().is_open()` instead")
 def is_open():
     return _default_modal.is_open()
 
-@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
-                        current_version='0.0.6',
+@deprecated(deprecated_in="0.1.0", removed_in="1.0.0",
+                        current_version='0.1.0',
                         details="Use the `Modal().open()` instead")
 def open():  # pylin: disable=redefined-builtin
     return _default_modal.open()
 
-@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
-                        current_version='0.0.6',
+@deprecated(deprecated_in="0.1.0", removed_in="1.0.0",
+                        current_version='0.1.0',
                         details="Use the `Modal().close()` instead")
 def close():
     return _default_modal.close()
 
 
 @contextmanager
-@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
-                        current_version='0.0.6',
+@deprecated(deprecated_in="0.1.0", removed_in="1.0.0",
+                        current_version='0.1.0',
                         details="Use the `Modal().container()` instead")
 def container(title=None, padding=100, max_width=None):
     _default_modal.title = title

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -68,7 +68,7 @@ class Modal:
                 width: unset !important;
                 background-color: #fff;
                 padding: {self.padding}px;
-                margin-top: -{self.padding}px;
+                margin-top: {2*self.padding}px;
                 margin-left: -{self.padding}px;
                 margin-right: -{self.padding}px;
                 margin-bottom: -{2*self.padding}px;
@@ -87,6 +87,7 @@ class Modal:
 
             div[data-modal-container='true'][key='{self.key}'] > div > div:nth-child(2) > div > button {{
                 right: 0;
+                margin-top: {2*self.padding + 14}px;
             }}
             </style>
             """,

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 from contextlib import contextmanager
 
+from deprecation import deprecated
 import streamlit as st
 import streamlit.components.v1 as components
 
@@ -128,20 +129,29 @@ class Modal:
 
 _default_modal = Modal('', key='streamlit-modal-default')
 
-
+@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
+                        current_version='0.0.6',
+                        details="Use the `Modal().is_open()` instead")
 def is_open():
     return _default_modal.is_open()
 
-
+@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
+                        current_version='0.0.6',
+                        details="Use the `Modal().open()` instead")
 def open():  # pylin: disable=redefined-builtin
     return _default_modal.open()
 
-
+@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
+                        current_version='0.0.6',
+                        details="Use the `Modal().close()` instead")
 def close():
     return _default_modal.close()
 
 
 @contextmanager
+@deprecated(deprecated_in="0.0.6", removed_in="1.0.0",
+                        current_version='0.0.6',
+                        details="Use the `Modal().container()` instead")
 def container(title=None, padding=100, max_width=None):
     _default_modal.title = title
     _default_modal.padding = padding

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -137,7 +137,7 @@ def is_open():
 @deprecated(deprecated_in="0.1.0", removed_in="1.0.0",
                         current_version='0.1.0',
                         details="Use the `Modal().open()` instead")
-def open():  # pylin: disable=redefined-builtin
+def open():  # pylint: disable=redefined-builtin
     return _default_modal.open()
 
 @deprecated(deprecated_in="0.1.0", removed_in="1.0.0",


### PR DESCRIPTION
Use multiple streamlit modal in streamlit can cause `key` conflicts,  this pr enhanced isolation.
Thanks for review. 

What's changed:

- Added new Class `Modal` to support modal pop-up by instance
- Added `.gitignore` config for Python 
- Added deprecation warning for old-style singleton modal