### PR TITLE
Update __init__.py

### DIFF
--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -39,7 +39,7 @@ class Modal:
                 position: fixed;
                 width: 100vw !important;
                 left: 0;
-                z-index: 1001;
+                z-index: 999992;
             }}
 
             div[data-modal-container='true'][key='{self.key}'] > div:first-child {{


### PR DESCRIPTION
I dont understand enough about css, and most of my work is more trial and error. Anyway the sidebar z-index is 999991.  Trying it in the console: Changing the  div[data-modal-container='true'][key='{self.key}'] z-index to 999991 works.  I guess you might want to change the other z-indexes as well. Yet, Weirdly -- despite the z-index being set to 1000 eg for the "before" -- it will still be on-top of the 999991 sidebar. Here is where my css knowledge ends. It might just be that it wont matter what z-index the "before" has.

I suggest to change only the z-index in ne line to 999992 and see if it works? But you know better what the others child css-lines do and if the z-indexes might ruin something which is not in the demo.