### PR TITLE
Update for all versions of Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-# What my fork do ?
-
-## Description
-- Update ```st.experimental_rerun()``` to ```st.rerun()```
-- Add a condition to use always ```st.exprimental_rerun()``` if Streamlit version under 1.27
-
-## How to use:
-- Download ```streamlit_modal folder``` with ```__init__.py```
-- Put ```streamlit_modal folder``` folder at the root of your python script
-- Don't forget to install ```deprecation``` package (```pip install deprecation```)
-- That all folks !
-
 # Streamlit modal
 
 Modal support for streamlit. The hackish way.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# What my fork do ?
+
+## Description
+- Update ```st.experimental_rerun()``` to ```st.rerun()```
+- Add a condition to use always ```st.exprimental_rerun()``` if Streamlit version under 1.27
+
+## How to use:
+- Download ```streamlit_modal folder``` with ```__init__.py```
+- Put ```streamlit_modal folder``` folder at the root of your python script
+- Don't forget to install ```deprecation``` package (```pip install deprecation```)
+- That all folks !
+
 # Streamlit modal
 
 Modal support for streamlit. The hackish way.

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -4,6 +4,12 @@ from deprecation import deprecated
 import streamlit as st
 import streamlit.components.v1 as components
 
+try:
+    from streamlit import rerun as rerun  # type: ignore
+except ImportError:
+    # conditional import for streamlit version <1.27
+    from streamlit import experimental_rerun as rerun  # type: ignore
+
 
 class Modal:
 
@@ -18,12 +24,12 @@ class Modal:
 
     def open(self):
         st.session_state[f'{self.key}-opened'] = True
-        st.experimental_rerun()
+        rerun()
 
     def close(self, rerun=True):
         st.session_state[f'{self.key}-opened'] = False
         if rerun:
-            st.experimental_rerun()
+            rerun()
 
     @contextmanager
     def container(self):

--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -26,9 +26,9 @@ class Modal:
         st.session_state[f'{self.key}-opened'] = True
         rerun()
 
-    def close(self, rerun=True):
+    def close(self, rerun_condition=True):
         st.session_state[f'{self.key}-opened'] = False
-        if rerun:
+        if rerun_condition:
             rerun()
 
     @contextmanager


### PR DESCRIPTION
## Description
- Update st.experimental_rerun() to st.rerun()
- Add a condition to use always st.exprimental_rerun() if Streamlit version under 1.27

## How to use:
- download streamlit_modal folder with __init__.py from my fork https://github.com/Jumitti/streamlit_modal
- put streamlit_modal folder at the root of your python script
- don't forget to install ```deprecation``` package (```pip install deprecation```)
- That all folks !