### PR TITLE
fix: move X button to the same level of title

### DIFF
--- a/streamlit_modal/__init__.py
+++ b/streamlit_modal/__init__.py
@@ -109,13 +109,17 @@ class Modal:
         )
         with st.container():
             _container = st.container()
+            
+            title, close_button = _container.columns([0.9, 0.1])
             if self.title:
-                _container.markdown(
-                    f"<h2>{self.title}</h2>", unsafe_allow_html=True)
-
-            close_ = st.button('X', key=f'{self.key}-close')
-            if close_:
-                self.close()
+                with title:
+                    st.header(self.title)
+            with close_button:
+                close_ = st.button('X', key=f'{self.key}-close')
+                if close_:
+                    self.close()
+            
+            _container.divider()
 
         components.html(
             f"""


### PR DESCRIPTION
Currently, the X button (close button) is at the bottom of the modal, which is quite weird and undesired.
This PR aims to handle that by creating two columns: the first one is for the title, the second one is for the close button.

Note that the divider is creating a lot of space. But this could be enhanced later. Any discussion is welcome!

Preview of the changes to the modal:
- With title:
<img width="662" alt="With Title" src="https://github.com/teamtv/streamlit_modal/assets/29520244/5e178312-35e6-4413-a369-fedea012dea5">

- No title:
<img width="638" alt="No Title" src="https://github.com/teamtv/streamlit_modal/assets/29520244/99de80a8-97dd-4e65-825c-1a08698a9e78">
